### PR TITLE
feat(models): introduce Snowflake type and improve model consistency

### DIFF
--- a/botato/models/base.py
+++ b/botato/models/base.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class BotatoBase(BaseModel):
+    """
+    Base model for Botato.
+    """
+
+    some_field: str = Field(..., description="A required string field")
+
+    model_config = ConfigDict(
+        extra="allow",
+        arbitrary_types_allowed=True,
+        json_encoders={
+            set: lambda v: list(v),
+        },
+    )

--- a/botato/models/channel.py
+++ b/botato/models/channel.py
@@ -1,16 +1,15 @@
-from pydantic import BaseModel, ConfigDict
+from botato.models.base import BotatoBase
 from typing import Optional, List
 from botato.models.user import User
 
 
-class Channel(BaseModel):
+class Channel(BotatoBase):
     """
     Represents a Discord channel.
 
     Documentation:
     https://discord.com/developers/docs/resources/channel#channels-resource
     """
-    model_config = ConfigDict(extra="allow")
     
     id: str
     type: int
@@ -48,14 +47,13 @@ class Channel(BaseModel):
     default_sort_order: Optional[int] = None
     default_forum_layout: Optional[int] = None
         
-class ChannelMention(BaseModel):
+class ChannelMention(BotatoBase):
     """
     Represents a mention of a channel in a Discord message.
 
     Documentation:
     https://discord.com/developers/docs/resources/message#channel-mention-object
     """
-    model_config = ConfigDict(extra="allow")
     
     id: str
     guild_id: str

--- a/botato/models/embed.py
+++ b/botato/models/embed.py
@@ -1,23 +1,21 @@
-from pydantic import BaseModel, ConfigDict
+from botato.models.base import BotatoBase
 from typing import Optional, List
 
 
-class EmbedField(BaseModel):
+class EmbedField(BotatoBase):
     """
     Represents a field in an embed.
     """
-    model_config = ConfigDict(extra="allow")
     
     name: str
     value: str
     inline: Optional[bool] = None
         
 
-class EmbedAuthor(BaseModel):
+class EmbedAuthor(BotatoBase):
     """
     Represents the author of an embed.
     """
-    model_config = ConfigDict(extra="allow")
     
     name: str
     url: Optional[str] = None
@@ -25,21 +23,19 @@ class EmbedAuthor(BaseModel):
     proxy_icon_url: Optional[str] = None
         
 
-class EmbedProvider(BaseModel):
+class EmbedProvider(BotatoBase):
     """
     Represents a provider of an embed.
     """
-    model_config = ConfigDict(extra="allow")
     
     name: Optional[str] = None
     url: Optional[str] = None
         
 
-class EmbedVideo(BaseModel):
+class EmbedVideo(BotatoBase):
     """
     Represents a video in an embed.
     """
-    model_config = ConfigDict(extra="allow")
     
     url: Optional[str] = None
     proxy_url: Optional[str] = None
@@ -47,11 +43,10 @@ class EmbedVideo(BaseModel):
     width: Optional[int] = None
         
         
-class EmbedImage(BaseModel):
+class EmbedImage(BotatoBase):
     """
     Represents an image in an embed.
     """
-    model_config = ConfigDict(extra="allow")
     
     url: Optional[str] = None
     proxy_url: Optional[str] = None
@@ -59,11 +54,10 @@ class EmbedImage(BaseModel):
     width: Optional[int] = None
         
         
-class EmbedThumbnail(BaseModel):
+class EmbedThumbnail(BotatoBase):
     """
     Represents a thumbnail in an embed.
     """
-    model_config = ConfigDict(extra="allow")
     
     url: Optional[str] = None
     proxy_url: Optional[str] = None
@@ -71,25 +65,23 @@ class EmbedThumbnail(BaseModel):
     width: Optional[int] = None
         
         
-class EmbedFooter(BaseModel):
+class EmbedFooter(BotatoBase):
     """
     Represents a footer in an embed.
     """
-    model_config = ConfigDict(extra="allow")
     
     text: str
     icon_url: Optional[str] = None
     proxy_icon_url: Optional[str] = None
         
     
-class Embed(BaseModel):
+class Embed(BotatoBase):
     """
     Represents an embed in a Discord message.
     
     Documentation:
     https://discord.com/developers/docs/resources/message#embed-object
     """
-    model_config = ConfigDict(extra="allow")
     
     title: Optional[str] = None
     type: Optional[str] = None

--- a/botato/models/emoji.py
+++ b/botato/models/emoji.py
@@ -1,22 +1,22 @@
-from pydantic import BaseModel, Field, ConfigDict
 from typing import Optional, List
+
+from botato.models.base import BotatoBase, Field
+from botato.models.snowflake import Snowflake
 from botato.models.user import User
-from botato.models.role import Role
 
 
-class Emoji(BaseModel):
+class Emoji(BotatoBase):
     """
     Represents a Discord emoji.
     
     Documentation:
     https://discord.com/developers/docs/resources/emoji#emoji-object
     """
-    model_config = ConfigDict(extra="allow")
     
-    id: Optional[str] = None
+    id: Optional[Snowflake] = None
     name: Optional[str] = None
-    roles: List[Role] = Field(default_factory=list)
-    user: Optional[User] = None
+    roles: List[Snowflake] = Field(default_factory=list)
+    user: User
     require_colons: bool = False
     managed: bool = False
     animated: bool = False

--- a/botato/models/guild.py
+++ b/botato/models/guild.py
@@ -1,44 +1,42 @@
-from pydantic import BaseModel, ConfigDict
 from typing import Optional, List
+
+from botato.models.base import BotatoBase
+from botato.models.snowflake import Snowflake
 from botato.models.role import Role
 
 
-class Guild(BaseModel):
+class Guild(BotatoBase):
     """
     Represents a Discord guild (server).
 
     Documentation:
     https://discord.com/developers/docs/resources/guild#guild-resource
-    
-    TODO:
-    - Add more fields as needed.
     """
-    model_config = ConfigDict(extra="allow")
     
-    id: str
+    id: Snowflake
     name: str
     icon: Optional[str] = None
     icon_hash: Optional[str] = None
     splash: Optional[str] = None
     discovery_splash: Optional[str] = None
     owner: Optional[bool] = None
-    owner_id: Optional[str] = None
+    owner_id: Optional[Snowflake] = None
     permissions: Optional[str] = None
     region: Optional[str] = None
-    afk_channel_id: Optional[str] = None
+    afk_channel_id: Optional[Snowflake] = None
     afk_timeout: Optional[int] = None
     widget_enabled: Optional[bool] = None
-    widget_channel_id: Optional[str] = None
+    widget_channel_id: Optional[Snowflake] = None
     verification_level: Optional[int] = None
     default_message_notifications: Optional[int] = None
     explicit_content_filter: Optional[int] = None
     roles: Optional[List[Role]] = None
     features: Optional[List[str]] = None
     mfa_level: Optional[int] = None
-    application_id: Optional[str] = None
-    system_channel_id: Optional[str] = None
+    application_id: Optional[Snowflake] = None
+    system_channel_id: Optional[Snowflake] = None
     system_channel_flags: Optional[int] = None
-    rules_channel_id: Optional[str] = None
+    rules_channel_id: Optional[Snowflake] = None
     max_presences: Optional[int] = None
     max_members: Optional[int] = None
     vanity_url_code: Optional[str] = None
@@ -47,14 +45,16 @@ class Guild(BaseModel):
     premium_tier: Optional[int] = None
     premium_subscription_count: Optional[int] = None
     preferred_locale: Optional[str] = None
-    public_updates_channel_id: Optional[str] = None
+    public_updates_channel_id: Optional[Snowflake] = None
     max_video_channel_users: Optional[int] = None
     max_stage_video_channel_users: Optional[int] = None
     approximate_member_count: Optional[int] = None
     approximate_presence_count: Optional[int] = None
-    welcome_screen: Optional[dict] = None # TODO: Define WelcomeScreen model
     nsfw_level: Optional[int] = None
-    stickers: Optional[List[dict]] = None  # TODO: Define Sticker model
     premium_progress_bar_enabled: Optional[bool] = None
-    safety_alerts_channel_id: Optional[str] = None
-    incidents_data: Optional[dict] = None  # TODO: Define IncidentsData model
+    safety_alerts_channel_id: Optional[Snowflake] = None
+    
+    # TODO: Define models for these
+    stickers: Optional[List[dict]] = None
+    incidents_data: Optional[dict] = None
+    welcome_screen: Optional[dict] = None

--- a/botato/models/interaction.py
+++ b/botato/models/interaction.py
@@ -1,0 +1,46 @@
+from typing import Optional, List, Literal, Union
+
+from botato.models.base import BotatoBase
+from botato.models.snowflake import Snowflake
+from botato.models.user import User
+from botato.models.member import Member
+from botato.models.message import Message
+
+
+class InteractionType:
+    PING = 1
+    APPLICATION_COMMAND = 2
+    MESSAGE_COMPONENT = 3
+    APPLICATION_COMMAND_AUTOCOMPLETE = 4
+    MODAL_SUBMIT = 5
+    
+
+class InteractionOption(BotatoBase):
+    name: str
+    type: int
+    value: Optional[Union[str, int, float, bool]] = None
+    options: Optional[List["InteractionOption"]] = None
+    focused: Optional[bool] = False
+    
+    
+class InteractionData(BotatoBase):
+    id: Snowflake
+    name: str
+    type: int
+    options: Optional[List[InteractionOption]] = None
+    custom_id: Optional[str] = None
+    component_type: Optional[int] = None
+    
+    
+class Interaction(BotatoBase):
+    id: Snowflake
+    application_id: Snowflake
+    type: int
+    data: Optional[InteractionData] = None
+    guild_id: Optional[Snowflake] = None
+    channel_id: Optional[Snowflake] = None
+    member: Optional[Member] = None
+    user: Optional[User] = None
+    token: str
+    version: int
+    message: Optional[Message] = None

--- a/botato/models/member.py
+++ b/botato/models/member.py
@@ -1,30 +1,31 @@
-from pydantic import BaseModel, Field, ConfigDict
 from typing import Optional, List
+from datetime import datetime
+
+from botato.models.base import BotatoBase, Field
+from botato.models.snowflake import Snowflake
 from botato.models.user import User
-from botato.models.role import Role
 from botato.models.user import AvatarDecorationData
 
 
-class Member(BaseModel):
+class Member(BotatoBase):
     """
     Represents a Discord member.
 
     Documentation:
     https://discord.com/developers/docs/resources/guild#guild-member-object
     """
-    model_config = ConfigDict(extra="allow")
     
     user: Optional[User] = None
     nick: Optional[str] = None
     avatar: Optional[str] = None
     banner: Optional[str] = None
-    roles: List[Role] = Field(default_factory=list)
-    joined_at: str
-    premium_since: Optional[str] = None
+    roles: List[Snowflake] = Field(default_factory=list)
+    joined_at: datetime
+    premium_since: Optional[datetime] = None
     deaf: bool
     mute: bool
     flags: int
     pending: Optional[bool] = None
     permissions: Optional[str] = None
-    communication_disabled_until: Optional[str] = None
+    communication_disabled_until: Optional[datetime] = None
     avatar_decoration_data: Optional[AvatarDecorationData] = None

--- a/botato/models/message.py
+++ b/botato/models/message.py
@@ -1,21 +1,22 @@
-from pydantic import BaseModel, Field, ConfigDict
 from typing import Optional, List
+from datetime import datetime
+
+from botato.models.base import BotatoBase, Field
+from botato.models.snowflake import Snowflake
 from botato.models.user import User
-from botato.models.member import Member
 from botato.models.role import Role
+from botato.models.channel import Channel
 from botato.models.channel import ChannelMention
 from botato.models.embed import Embed
 from botato.models.reaction import Reaction
-from botato.models.channel import Channel
     
 
-class Attachment(BaseModel):
+class Attachment(BotatoBase):
     """
     Represents an attachment in a Discord message.
     """
-    model_config = ConfigDict(extra="allow")
     
-    id: str
+    id: Snowflake
     filename: str
     title: Optional[str] = None
     description: Optional[str] = None
@@ -31,47 +32,48 @@ class Attachment(BaseModel):
     flags: Optional[int] = None
 
 
-class Message(BaseModel):
+class Message(BotatoBase):
     """
     Represents a Discord message object.
 
     Documentation:
     https://discord.com/developers/docs/resources/message#messages-resource
     """
-    model_config = ConfigDict(extra="allow")
     
-    id: str
-    channel_id: str
+    id: Snowflake
+    channel_id: Snowflake
     author: User
     content: str
-    timestamp: str
-    edited_timestamp: Optional[str] = None
+    timestamp: datetime
+    edited_timestamp: Optional[datetime] = None
     tts: bool
     mention_everyone: bool
     mentions: List[User] = Field(default_factory=list)
-    mention_roles: List[Role] = Field(default_factory=list)
-    mention_channels: List[ChannelMention] = Field(default_factory=list)
+    mention_roles: List[Snowflake] = Field(default_factory=list)
+    mention_channels: Optional[List[ChannelMention]] = Field(default_factory=list)
     attachments: List[Attachment] = Field(default_factory=list)
     embeds: List[Embed] = Field(default_factory=list)
-    reactions: List[Reaction] = Field(default_factory=list)
+    reactions: Optional[List[Reaction]] = Field(default_factory=list)
     nonce: Optional[str | int] = None
     pinned: bool
-    webhook_id: Optional[str] = None
+    webhook_id: Optional[Snowflake] = None
     type: int
-    activity: Optional[dict] = None
-    application: Optional[dict] = None
     application_id: Optional[str] = None
     flags: Optional[int] = None
+    referenced_message: Optional["Message"] = None
+    thread: Optional[Channel] = None
+    position: Optional[int] = None
+
+    # TODO: Create models for these fields
+    activity: Optional[dict] = None
+    application: Optional[dict] = None
     message_reference: Optional[dict] = None
     message_snapshots: Optional[List[dict]] = None
-    referenced_message: Optional["Message"] = None
     interaction_metadata: Optional[dict] = None
     interaction: Optional[dict] = None
-    thread: Optional[Channel] = None
     components: Optional[List[dict]] = None
     sticker_items: Optional[List[dict]] = None
     stickers: Optional[List[dict]] = None
-    position: Optional[int] = None
     role_subscription_data: Optional[dict] = None
     resolved: Optional[dict] = None
     poll: Optional[dict] = None

--- a/botato/models/reaction.py
+++ b/botato/models/reaction.py
@@ -1,22 +1,20 @@
-from pydantic import BaseModel, ConfigDict
+from botato.models.base import BotatoBase
 from typing import Optional, List
 from botato.models.emoji import Emoji
 
-class ReactionCountDetails(BaseModel):
+class ReactionCountDetails(BotatoBase):
     """
     Represents the details of a reaction count.
     """
-    model_config = ConfigDict(extra="allow")
     
     burst: int
     normal: int
     
 
-class Reaction(BaseModel):
+class Reaction(BotatoBase):
     """
     Represents a reaction to a message.
     """
-    model_config = ConfigDict(extra="allow")
     
     count: int
     count_details: Optional[ReactionCountDetails] = None

--- a/botato/models/role.py
+++ b/botato/models/role.py
@@ -1,14 +1,13 @@
-from pydantic import BaseModel, ConfigDict
-from typing import Optional
+from botato.models.base import BotatoBase
+from botato.models.snowflake import Snowflake
 
 
-class Role(BaseModel):
+class Role(BotatoBase):
     """
     Represents a Discord role.
     """
-    model_config = ConfigDict(extra="allow")
     
-    id: str
+    id: Snowflake
     name: str
     color: int
     hoist: bool

--- a/botato/models/snowflake.py
+++ b/botato/models/snowflake.py
@@ -1,0 +1,51 @@
+from botato.models.base import BotatoBase
+from datetime import datetime
+
+
+DISCORD_EPOCH = 1420070400000
+
+class Snowflake(str):
+    """
+    Represents a Discord Snowflake ID.
+
+    Internally, it's a string, but this gives semantic meaning
+    and allows for future helpers like `.timestamp()` or `.as_int()`.
+    """
+
+    def __new__(cls, value: str | int) -> "Snowflake":
+        if isinstance(value, int):
+            value = str(value)
+        elif not isinstance(value, str):
+            raise TypeError("Snowflake must be initialized with a string or integer")
+        if not value.isdigit():
+            raise ValueError("Snowflake must be numeric")
+        return super().__new__(cls, value)
+    
+    def as_int(self) -> int:
+        """Return the snowflake as an integer."""
+        return int(self)
+    
+    def timestamp(self) -> datetime:
+        """
+        Return the Discord timestamp from the snowflake bits.
+
+        Snowflake format:
+        - 42 bits: timestamp offset from Discord Epoch
+        - 22 bits: internal worker/process IDs and increment
+        """
+        timestamp_ms = (int(self) >> 22) + DISCORD_EPOCH
+        return datetime.fromtimestamp(timestamp_ms / 1000)
+    
+    def __int__(self) -> int:
+        return self.as_int()
+    
+    def __repr__(self) -> str:
+        return f"Snowflake({super().__repr__()})"
+    
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, (str, int)):
+            return int(self) == int(other)
+        return super().__eq__(other)
+    
+    def __hash__(self) -> int:
+        return hash(int(self))

--- a/botato/models/user.py
+++ b/botato/models/user.py
@@ -1,27 +1,26 @@
-from pydantic import BaseModel, ConfigDict
+from botato.models.base import BotatoBase
+from botato.models.snowflake import Snowflake
 from typing import Optional
 
 
-class AvatarDecorationData(BaseModel):
+class AvatarDecorationData(BotatoBase):
     """
     Represents the avatar decoration data for a Discord user.
     """
-    model_config = ConfigDict(extra="allow")
     
     asset: str
     sku_id: str
 
 
-class User(BaseModel):
+class User(BotatoBase):
     """
     Represents a Discord user.
 
     Documentation:
     https://discord.com/developers/docs/resources/user#user-object
     """
-    model_config = ConfigDict(extra="allow")
     
-    id: str
+    id: Snowflake
     username: str
     discriminator: str # Note: not used for users anymore, only for bots
     global_name: str | None = None


### PR DESCRIPTION
Add a Snowflake class to represent Discord IDs with helper methods for
timestamp extraction and integer conversion. Update Guild and Member
models to use Snowflake for ID fields, improving type safety and clarity.
Refactor embed-related models to inherit from BotatoBase for consistency.
Convert datetime fields in Member to proper datetime types for better
handling of timestamps. These changes enhance data integrity and prepare
the codebase for future extensions.