### PR TITLE
fix(models): remove unused field from BotatoBase model

### DIFF
--- a/botato/models/base.py
+++ b/botato/models/base.py
@@ -6,8 +6,6 @@ class BotatoBase(BaseModel):
     Base model for Botato.
     """
 
-    some_field: str = Field(..., description="A required string field")
-
     model_config = ConfigDict(
         extra="allow",
         arbitrary_types_allowed=True,


### PR DESCRIPTION
Remove the required field `some_field` from the BotatoBase model to
clean up the base model definition. This change simplifies the model
and avoids unnecessary validation requirements.