### PR TITLE
docs: update production URL to root domain

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -10,7 +10,7 @@ const config: Config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://shivkun.github.io/botato',
+  url: 'https://shivkun.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/botato/',


### PR DESCRIPTION
Change the production URL from 'https://shivkun.github.io/botato' to
'https://shivkun.github.io' to correctly reflect the root domain of the
site. This ensures that the site is served properly under the specified
baseUrl '/botato/' on GitHub Pages.