### PR TITLE
docs: disable trailing slashes in URLs for cleaner paths

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -14,6 +14,7 @@ const config: Config = {
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/botato/',
+  trailingSlash: false,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
Add trailingSlash: false to docusaurus.config.ts to remove trailing
slashes from generated URLs. This change improves URL consistency
and avoids potential duplicate content issues on the site.