### PR TITLE
docs: simplify poetry environment activation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ poetry install
 Activate the environment:
 
 ```bash
-poetry env activate $(poetry env list --full-path | head -n 1)
+poetry env activate
 ```
 
 Run the example bot:


### PR DESCRIPTION
Update README to use a simpler command for activating the poetry
environment. This change improves clarity and reduces potential errors
by removing the complex command substitution, making it easier for
users to follow the setup instructions.