### PR TITLE
chore: add project URLs and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__/
 .env
 # Ignore .DS_Store files
 .DS_Store
+# Ignore build files
+build/
+dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,11 @@ classifiers = [
     "Development Status :: 3 - Alpha"
 ]
 
+[tool.poetry.urls]
+homepage = "https://github.com/shivkun/botato"
+documentation = "https://shivkun.github.io/botato"
+issues = "https://github.com/shivkun/botato/issues"
+
 [tool.poetry.dependencies]
 python = "^3.13"
 aiohttp = "^3.11.18"


### PR DESCRIPTION
Add homepage, documentation, and issues URLs to pyproject.toml to
improve project metadata and make it easier for users to find
resources. Update .gitignore to exclude build and dist directories,
preventing accidental commits of build artifacts.