### PR TITLE
docs: improve on_message_create example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ Register events with decorators:
 
 ```python
 @bot.event
-async def on_message_create(data):
-    print(data["content"])
+async def on_message_create(message: Message):
+    print(f"{message.author.username}: {message.content}")
 ```
 
 ## 🚀 Deployment <a name = "deployment"></a>


### PR DESCRIPTION
Update the on_message_create event handler example to use the
Message object instead of raw data. This change clarifies how to
access message author and content, making the example more
readable and aligned with the library's usage.