### PR TITLE
feat(models): enhance user, role, reaction models and add hex color type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,56 @@
-# Ignore Python bytecode files
-*.pyc
+# Byte-compiled / cache
 __pycache__/
-# Ignore environment variables
-.env
-# Ignore .DS_Store files
+*.py[cod]
+*.pyo
+*.pyd
+*.pdb
+*.so
+*.egg-info/
+.eggs/
+*.manifest
+*.spec
+
+# Poetry virtual environments (if using .venv)
+.venv/
+env/
+venv/
+
+# pytest cache
+.pytest_cache/
+.coverage
+htmlcov/
+*.cover
+*.log
+
+# MyPy / Ruff / Coverage
+.mypy_cache/
+.cache/
+.dmypy.json
+*.py,cover
+.tox/
+
+# Jupyter / IPython
+.ipynb_checkpoints/
+.profile/
+
+# Editors
+.vscode/
+.idea/
+*.sublime-project
+*.sublime-workspace
+
+# macOS/Linux
 .DS_Store
-# Ignore build files
+Thumbs.db
+*.swp
+
+# Build
 build/
 dist/
+
+# Poetry
+poetry.lock
+
+# Environment variables
+.env
+.env.*

--- a/botato/models/reaction.py
+++ b/botato/models/reaction.py
@@ -1,6 +1,7 @@
 from botato.models.base import BotatoBase
 from typing import Optional, List
 from botato.models.emoji import Emoji
+from botato.types.hex_color import HexColor
 
 class ReactionCountDetails(BotatoBase):
     """
@@ -17,8 +18,8 @@ class Reaction(BotatoBase):
     """
     
     count: int
-    count_details: Optional[ReactionCountDetails] = None
+    count_details: ReactionCountDetails
     me: bool
     me_burst: bool
     emoji: Emoji
-    burst_colors: Optional[List[str]] = None
+    burst_colors: List[HexColor]

--- a/botato/models/role.py
+++ b/botato/models/role.py
@@ -1,12 +1,33 @@
-from botato.models.base import BotatoBase
+from botato.models.base import BotatoBase, Field
 from botato.models.snowflake import Snowflake
+from typing import Optional, List
 
+class RoleTag(BotatoBase):
+    """
+    Represents a tag associated with a Discord role.
+    """
+    
+    bot_id: Optional[Snowflake] = Field(default=None)
+    integration_id: Optional[Snowflake] = Field(default=None)
+    subscription_listing_id: Optional[Snowflake] = Field(default=None)
+    
+    """
+    Fields `premium_subscriber`, `available_for_purchase`, and `guild_connections`
+    have a type `null` which represent booleans: they will be present and set to `null`
+    if they are "true", and will be not present if they are "false".
+    
+    Defaulting to `false` for these fields makes them not present.
+    """
+    premium_subscriber: Optional[bool] = Field(default=False)
+    available_for_purchase: Optional[bool] = Field(default=False)
+    guild_connections: Optional[bool] = Field(default=False)
 
 class Role(BotatoBase):
     """
     Represents a Discord role.
     """
     
+    # Required, non-nullable
     id: Snowflake
     name: str
     color: int
@@ -15,3 +36,11 @@ class Role(BotatoBase):
     permissions: str
     managed: bool
     mentionable: bool
+    flags: int
+    
+    # Optional, non-nullable
+    tags: Optional[List[RoleTag]] = Field(default={})
+    
+    # Optional, nullable (can be None)
+    icon: Optional[str] = Field(default=None)
+    unicode_emoji: Optional[str] = Field(default=None)

--- a/botato/models/user.py
+++ b/botato/models/user.py
@@ -1,4 +1,4 @@
-from botato.models.base import BotatoBase
+from botato.models.base import BotatoBase, Field
 from botato.models.snowflake import Snowflake
 from typing import Optional
 
@@ -9,7 +9,7 @@ class AvatarDecorationData(BotatoBase):
     """
     
     asset: str
-    sku_id: str
+    sku_id: Snowflake
 
 
 class User(BotatoBase):
@@ -18,22 +18,41 @@ class User(BotatoBase):
 
     Documentation:
     https://discord.com/developers/docs/resources/user#user-object
+    
+    Note: Example Nullable and Optional fields
+    - FIELD                     TYPE
+    - `optional_field?`         string
+    - `nullable_field`          ?string
+    - `optional_and_nullable?` ?string
+    
+    Examples:
+    - User(id=123456789012345678, username="example", discriminator="0001", global_name=None, avatar=None, ...) 
+    -> this is valid because all required fields are present, even if some are None.
+    - User(id=123456789012345678, username="example", discriminator="0001", global_name=None, ...) 
+    -> this is invalid because `avatar` is required but not provided, is missing.
     """
     
+    # Required, non-nullable
     id: Snowflake
     username: str
-    discriminator: str # Note: not used for users anymore, only for bots
-    global_name: str | None = None
-    avatar: str | None = None
-    bot: Optional[bool] = False
-    system: Optional[bool] = False
-    mfa_enabled: Optional[bool] = False
-    banner: Optional[str] = None
-    accent_color: Optional[int] = None
-    locale: Optional[str] = None
-    verified: Optional[bool] = False
-    email: Optional[str] = None
-    flags: Optional[int] = None
-    premium_type: Optional[int] = None
-    public_flags: Optional[int] = None
-    avatar_decoration_data: Optional[AvatarDecorationData] = None
+    discriminator: str
+    
+    # Required, nullable (must be present, can be None)
+    global_name: Optional[str] = Field(...)
+    avatar: Optional[str] = Field(...)
+    
+    # Optional, non-nullable
+    bot: Optional[bool] = Field(default=False)
+    system: Optional[bool] = Field(default=False)
+    mfa_enabled: Optional[bool] = Field(default=False)
+    locale: Optional[str] = Field(default="en-US")
+    verified: Optional[bool] = Field(default=False)
+    flags: Optional[int] = Field(default=0)
+    premium_type: Optional[int] = Field(default=0)
+    public_flags: Optional[int] = Field(default=0)
+    
+    # Optional, nullable (can be None)
+    banner: Optional[str] = Field(default=None)
+    accent_color: Optional[int] = Field(default=None)
+    email: Optional[str] = Field(default=None)
+    avatar_decoration_data: Optional[AvatarDecorationData] = Field(default=None)

--- a/botato/types/hex_color.py
+++ b/botato/types/hex_color.py
@@ -1,0 +1,27 @@
+"""
+This defines a new type of 'hex' that is used to represent a hex value.
+This allows more control and validation over a standard 'str' type.
+"""
+import re
+from pydantic.validators import str_validator
+
+class HexColor(str):
+    _pattern = re.compile(r'^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$')
+    
+    @classmethod
+    def __get_validators__(cls):
+        yield str_validator
+        yield cls.validate
+        
+    @classmethod
+    def validate(cls, v: str) -> 'HexColor':
+        match = cls._pattern.fullmatch(v)
+        if not match:
+            raise ValueError(f"{v} is not a valid hex color")
+        
+        hex_value = match.group(1).lower()
+        
+        if len(hex_value) == 3:
+            hex_value = ''.join(c*2 for c in hex_value)
+            
+        return cls(f'#{hex_value}')


### PR DESCRIPTION
Add HexColor type for validated hex color strings to improve color
handling. Update Reaction model to use HexColor for burst_colors and
make count_details non-optional for consistency.

Refine User and Role models by adding Field imports and stricter types,
including Snowflake for sku_id and optional booleans with default False
in RoleTag to handle nullable Discord API fields correctly.

Expand .gitignore to cover common Python, editor, and environment files
to reduce unwanted files in version control.